### PR TITLE
gh-12 Not allow login for deactivated users

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/authentication/OpenidConnectAuthenticationService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/authentication/OpenidConnectAuthenticationService.groovy
@@ -110,6 +110,11 @@ class OpenidConnectAuthenticationService implements AuthenticationSchemeService 
 
         CatalogueUser user = catalogueUserService.findByEmailAddress(emailAddress)
 
+        if (user?.isDisabled()) {
+            // User is not active, so return null
+            return null
+        }
+
         if (!user) {
             log.info('Creating new user {}', emailAddress)
 


### PR DESCRIPTION
gh-12 Login is not allowed through Microsoft provider if the user is deactivated in the Admin config