### PR TITLE
Using Issuer URL host instead of authority

### DIFF
--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/authentication/OpenidConnectAuthenticationService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/authentication/OpenidConnectAuthenticationService.groovy
@@ -120,7 +120,7 @@ class OpenidConnectAuthenticationService implements AuthenticationSchemeService 
                                                       password: null,
                                                       firstName: userInfoBody.given_name ?: 'Unknown',
                                                       lastName: userInfoBody.family_name ?: 'Unknown',
-                                                      createdBy: "openidConnectAuthentication@${issuerUrl.authority}",
+                                                      createdBy: "openidConnectAuthentication@${issuerUrl.host}",
                                                       pending: false,
                                                       creationMethod: 'OpenID-Connect')
 


### PR DESCRIPTION
In case Issuer URL authority contains a port several exceptions are raised. Using host will "remove" the port part.

Fix as suggested in  for https://github.com/MauroDataMapper-Plugins/mdm-plugin-authentication-openid-connect/issues/16.