### PR TITLE
Fix intermittent errors when handling multiple requests from UI

### DIFF
--- a/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/provider/OpenidConnectProvider.groovy
+++ b/grails-app/domain/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/provider/OpenidConnectProvider.groovy
@@ -84,10 +84,10 @@ class OpenidConnectProvider implements MdmDomain {
     }
 
     def beforeValidate() {
-        authorizationEndpointParameters?.openidConnectProvider = this
-        authorizationEndpointParameters?.createdBy = this.createdBy
-        discoveryDocument?.openidConnectProvider = this
-        discoveryDocument?.createdBy = this.createdBy
+        if (authorizationEndpointParameters?.openidConnectProvider != this) authorizationEndpointParameters?.openidConnectProvider = this
+        if (authorizationEndpointParameters?.createdBy != this.createdBy) authorizationEndpointParameters?.createdBy = this.createdBy
+        if (discoveryDocument?.openidConnectProvider != this) discoveryDocument?.openidConnectProvider = this
+        if (discoveryDocument?.createdBy != this.createdBy) discoveryDocument?.createdBy = this.createdBy
     }
 
     Map<String, String> getAccessTokenRequestParameters(String code, String redirectUri, String sessionState) {

--- a/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/token/OpenidConnectTokenService.groovy
+++ b/grails-app/services/uk/ac/ox/softeng/maurodatamapper/plugins/authentication/openid/connect/token/OpenidConnectTokenService.groovy
@@ -27,6 +27,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException
 import com.auth0.jwt.interfaces.DecodedJWT
 import grails.gorm.transactions.Transactional
 import groovy.util.logging.Slf4j
+import org.springframework.orm.hibernate5.HibernateOptimisticLockingFailureException
 
 @Slf4j
 @Transactional
@@ -66,7 +67,12 @@ class OpenidConnectTokenService {
         if (!openidConnectToken.validate()) {
             throw new ApiInvalidModelException('OCTSS02', 'Could not update and store openid connect token', openidConnectToken.errors)
         }
-        openidConnectToken.save(validate: false, flush: true)
+        try {
+            openidConnectToken.save(validate: false, flush: true)
+        } catch (HibernateOptimisticLockingFailureException hibernateOptimisticLockingFailureException) {
+            // if the token refresh update is stale, another thread has probably refreshed at the same time
+            log.warn 'Ignored HibernateOptimisticLockingFailureException on OpenidConnectTokenService.validateAndSave', hibernateOptimisticLockingFailureException
+        }
     }
 
     boolean verifyIdToken(OpenidConnectToken token, String lastKnownSessionState) {


### PR DESCRIPTION
* Update build files to new server
* Try to reduce updates in beforeValidate
* Ignore StaleStateException on refreshing token. If this occurs, another thread has successfully refreshed the token at the same time so we can ignore the error.